### PR TITLE
Change Transition Style enum to not conflict with MZFormSheetController

### DIFF
--- a/Example/Objective-C/MZFormSheetPresentationController Objective-C Example/ViewController.m
+++ b/Example/Objective-C/MZFormSheetPresentationController Objective-C Example/ViewController.m
@@ -24,7 +24,7 @@
     // Set Default Background collor for all presentation controllers
     [[MZFormSheetPresentationController appearance] setBackgroundColor:[[UIColor darkGrayColor] colorWithAlphaComponent:0.3]];
 
-    [MZFormSheetPresentationController registerTransitionClass:[CustomTransition class] forTransitionStyle:MZFormSheetTransitionStyleCustom];
+    [MZFormSheetPresentationController registerTransitionClass:[CustomTransition class] forTransitionStyle:MZFormSheetPresentationTransitionStyleCustom];
 }
 
 - (UINavigationController *)formSheetControllerWithNavigationController {
@@ -157,9 +157,9 @@
     UINavigationController *navigationController = [self formSheetControllerWithNavigationController];
     MZFormSheetPresentationController *formSheetController = [[MZFormSheetPresentationController alloc] initWithContentViewController:navigationController];
     formSheetController.shouldDismissOnBackgroundViewTap = YES;
-    formSheetController.contentViewControllerTransitionStyle = (MZFormSheetTransitionStyle)transition;
+    formSheetController.contentViewControllerTransitionStyle = (MZFormSheetPresentationTransitionStyle)transition;
     
-    [self presentViewController:formSheetController animated:(transition != MZFormSheetTransitionStyleNone) completion:nil];
+    [self presentViewController:formSheetController animated:(transition != MZFormSheetPresentationTransitionStyleNone) completion:nil];
 }
 
 - (void)presentFormSheetControllerWithKeyboardMovement:(NSInteger)movementOption {
@@ -167,7 +167,7 @@
     MZFormSheetPresentationController *formSheetController = [[MZFormSheetPresentationController alloc] initWithContentViewController:navigationController];
     formSheetController.shouldDismissOnBackgroundViewTap = YES;
     formSheetController.movementActionWhenKeyboardAppears = (MZFormSheetActionWhenKeyboardAppears)movementOption;
-    formSheetController.contentViewControllerTransitionStyle = MZFormSheetTransitionStyleFade;
+    formSheetController.contentViewControllerTransitionStyle = MZFormSheetPresentationTransitionStyleFade;
     PresentedTableViewController *presentedViewController = [navigationController.viewControllers firstObject];
     presentedViewController.textFieldBecomeFirstResponder = YES;
     

--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.h
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.h
@@ -50,9 +50,9 @@ typedef void(^MZFormSheetPresentationControllerTransitionHandler)();
  *  @param transitionClass Custom transition class.
  *  @param transitionStyle The transition style to use when presenting the receiver.
  */
-+ (void)registerTransitionClass:(Class __nonnull)transitionClass forTransitionStyle:(MZFormSheetTransitionStyle)transitionStyle;
++ (void)registerTransitionClass:(Class __nonnull)transitionClass forTransitionStyle:(MZFormSheetPresentationTransitionStyle)transitionStyle;
 
-+ (nullable Class)classForTransitionStyle:(MZFormSheetTransitionStyle)transitionStyle;
++ (nullable Class)classForTransitionStyle:(MZFormSheetPresentationTransitionStyle)transitionStyle;
 /**
  *  The view controller responsible for the content portion of the popup.
  */
@@ -106,9 +106,9 @@ typedef void(^MZFormSheetPresentationControllerTransitionHandler)();
 
 /**
  The transition style to use when presenting the receiver.
- By default, this is MZFormSheetTransitionStyleSlideFromTop.
+ By default, this is MZFormSheetPresentationTransitionStyleSlideFromTop.
  */
-@property (nonatomic, assign) MZFormSheetTransitionStyle contentViewControllerTransitionStyle MZ_APPEARANCE_SELECTOR;
+@property (nonatomic, assign) MZFormSheetPresentationTransitionStyle contentViewControllerTransitionStyle MZ_APPEARANCE_SELECTOR;
 
 /**
  The movement action to use when the keyboard appears.

--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.m
@@ -63,11 +63,11 @@ static NSMutableDictionary *_instanceOfTransitionClasses = nil;
 
 #pragma mark - Class methods
 
-+ (void)registerTransitionClass:(Class)transitionClass forTransitionStyle:(MZFormSheetTransitionStyle)transitionStyle {
++ (void)registerTransitionClass:(Class)transitionClass forTransitionStyle:(MZFormSheetPresentationTransitionStyle)transitionStyle {
     [[MZFormSheetPresentationController sharedTransitionClasses] setObject:transitionClass forKey:@(transitionStyle)];
 }
 
-+ (Class)classForTransitionStyle:(MZFormSheetTransitionStyle)transitionStyle {
++ (Class)classForTransitionStyle:(MZFormSheetPresentationTransitionStyle)transitionStyle {
     return [MZFormSheetPresentationController sharedTransitionClasses][@(transitionStyle)];
 }
 

--- a/MZFormSheetPresentationController/MZTransition.h
+++ b/MZFormSheetPresentationController/MZTransition.h
@@ -33,18 +33,18 @@ typedef void (^MZTransitionCompletionHandler)();
 
 @class MZFormSheetPresentationController;
 
-typedef NS_ENUM(NSInteger, MZFormSheetTransitionStyle) {
-  MZFormSheetTransitionStyleSlideFromTop = 0,
-  MZFormSheetTransitionStyleSlideFromBottom,
-  MZFormSheetTransitionStyleSlideFromLeft,
-  MZFormSheetTransitionStyleSlideFromRight,
-  MZFormSheetTransitionStyleSlideAndBounceFromLeft,
-  MZFormSheetTransitionStyleSlideAndBounceFromRight,
-  MZFormSheetTransitionStyleFade,
-  MZFormSheetTransitionStyleBounce,
-  MZFormSheetTransitionStyleDropDown,
-  MZFormSheetTransitionStyleCustom,
-  MZFormSheetTransitionStyleNone,
+typedef NS_ENUM(NSInteger, MZFormSheetPresentationTransitionStyle) {
+  MZFormSheetPresentationTransitionStyleSlideFromTop = 0,
+  MZFormSheetPresentationTransitionStyleSlideFromBottom,
+  MZFormSheetPresentationTransitionStyleSlideFromLeft,
+  MZFormSheetPresentationTransitionStyleSlideFromRight,
+  MZFormSheetPresentationTransitionStylelideAndBounceFromLeft,
+  MZFormSheetPresentationTransitionStyleSlideAndBounceFromRight,
+  MZFormSheetPresentationTransitionStyleFade,
+  MZFormSheetPresentationTransitionStyleBounce,
+  MZFormSheetPresentationTransitionStyleDropDown,
+  MZFormSheetPresentationTransitionStyleCustom,
+  MZFormSheetPresentationTransitionStyleNone,
 };
 
 @protocol MZFormSheetPresentationControllerTransitionProtocol <NSObject>

--- a/MZFormSheetPresentationController/MZTransition.m
+++ b/MZFormSheetPresentationController/MZTransition.m
@@ -54,7 +54,7 @@ CGFloat const MZTransitionDefaultDropDownDuration = 0.4;
 
 @implementation MZSlideFromTopTransition
 + (void)load {
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideFromTop];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleSlideFromTop];
 }
 
 - (void)entryFormSheetControllerTransition:(MZFormSheetPresentationController *)formSheetController completionHandler:(MZTransitionCompletionHandler)completionHandler {
@@ -89,8 +89,8 @@ CGFloat const MZTransitionDefaultDropDownDuration = 0.4;
 
 @implementation MZSlideFromBottomTransition
 + (void)load {
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideFromBottom];
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideFromBottom];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleSlideFromBottom];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleSlideFromBottom];
 }
 
 - (void)entryFormSheetControllerTransition:(MZFormSheetPresentationController *)formSheetController completionHandler:(MZTransitionCompletionHandler)completionHandler {
@@ -127,8 +127,8 @@ CGFloat const MZTransitionDefaultDropDownDuration = 0.4;
 
 @implementation MZSlideFromLeftTransition
 + (void)load {
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideFromLeft];
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideFromLeft];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleSlideFromLeft];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleSlideFromLeft];
 }
 
 - (void)entryFormSheetControllerTransition:(MZFormSheetPresentationController *)formSheetController completionHandler:(MZTransitionCompletionHandler)completionHandler {
@@ -163,8 +163,8 @@ CGFloat const MZTransitionDefaultDropDownDuration = 0.4;
 
 @implementation MZSlideFromRightTransition
 + (void)load {
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideFromRight];
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideFromRight];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleSlideFromRight];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleSlideFromRight];
 }
 
 - (void)entryFormSheetControllerTransition:(MZFormSheetPresentationController *)formSheetController completionHandler:(MZTransitionCompletionHandler)completionHandler {
@@ -199,8 +199,9 @@ CGFloat const MZTransitionDefaultDropDownDuration = 0.4;
 
 @implementation MZSlideBounceFromLeftTransition
 + (void)load {
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideAndBounceFromLeft];
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideAndBounceFromLeft];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:
+     MZFormSheetPresentationTransitionStylelideAndBounceFromLeft];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStylelideAndBounceFromLeft];
 }
 
 - (void)entryFormSheetControllerTransition:(MZFormSheetPresentationController *)formSheetController completionHandler:(MZTransitionCompletionHandler)completionHandler {
@@ -233,8 +234,8 @@ CGFloat const MZTransitionDefaultDropDownDuration = 0.4;
 
 @implementation MZSlideBounceFromRightTransition
 + (void)load {
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideAndBounceFromRight];
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleSlideAndBounceFromRight];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleSlideAndBounceFromRight];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleSlideAndBounceFromRight];
 }
 
 - (void)entryFormSheetControllerTransition:(MZFormSheetPresentationController *)formSheetController completionHandler:(MZTransitionCompletionHandler)completionHandler {
@@ -267,8 +268,8 @@ CGFloat const MZTransitionDefaultDropDownDuration = 0.4;
 
 @implementation MZFadeTransition
 + (void)load {
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleFade];
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleFade];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleFade];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleFade];
 }
 
 - (void)entryFormSheetControllerTransition:(MZFormSheetPresentationController *)formSheetController completionHandler:(MZTransitionCompletionHandler)completionHandler {
@@ -298,8 +299,8 @@ CGFloat const MZTransitionDefaultDropDownDuration = 0.4;
 
 @implementation MZBounceTransition
 + (void)load {
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleBounce];
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleBounce];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleBounce];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleBounce];
 }
 
 - (void)entryFormSheetControllerTransition:(MZFormSheetPresentationController *)formSheetController completionHandler:(MZTransitionCompletionHandler)completionHandler {
@@ -346,8 +347,8 @@ CGFloat const MZTransitionDefaultDropDownDuration = 0.4;
 
 @implementation MZDropDownTransition
 + (void)load {
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleDropDown];
-    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetTransitionStyleDropDown];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleDropDown];
+    [MZFormSheetPresentationController registerTransitionClass:self forTransitionStyle:MZFormSheetPresentationTransitionStyleDropDown];
 }
 
 - (void)entryFormSheetControllerTransition:(MZFormSheetPresentationController *)formSheetController completionHandler:(MZTransitionCompletionHandler)completionHandler {


### PR DESCRIPTION
I'm using MZFormSheetController in our iOS 7/8 app, I use it as a dependency within a couple of private Cocoapods. I use the MZFormSheetPresentationController for iOS 8 and MZFormSheetController for iOS 7.

Now MZFormSheetPresentationController is separated out pushing a Cocoapod Spec with both MZFormSheetController & MZFormSheetPresentationController it returns a "redefinition of enumerator" error.

This *should* resolve things I think, there might be a better solution.