### PR TITLE
Added horizontal offset property

### DIFF
--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.h
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.h
@@ -97,6 +97,12 @@ typedef void(^MZFormSheetPresentationControllerTransitionHandler)();
 @property (nonatomic, assign) BOOL shouldCenterVertically MZ_APPEARANCE_SELECTOR;
 
 /**
+ The orizontal offset of content view from the center.
+ By default, this is 0
+ */
+@property (nonatomic, assign) CGFloat contentViewOrizontalOffset MZ_APPEARANCE_SELECTOR;
+
+/**
  Returns whether the background view be touch transparent.
  If transparent is set to YES, background view will not recive touch and didTapOnBackgroundViewCompletionHandler will not be called.
  Also will not be possible to dismiss form sheet on background tap.

--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.m
@@ -410,6 +410,13 @@ static NSMutableDictionary *_instanceOfTransitionClasses = nil;
         frame.origin.y = self.topInset;
         self.contentViewController.view.frame = frame;
     }
+    
+    if (self.contentViewOrizontalOffset != 0)
+    {
+        CGRect frame = self.contentViewController.view.frame;
+        frame.origin.x = frame.origin.x + self.contentViewOrizontalOffset;
+        self.contentViewController.view.frame = frame;
+    }
 }
 
 #pragma mark - UIKeyboard Notifications


### PR DESCRIPTION
When using ipad, often you need the controller to be near one or the other side of the screen. This property controls the distance from the default horizontal position ( => horizontal center of the window).