### PR TITLE
Support App Extension

### DIFF
--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.m
@@ -194,7 +194,7 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
 }
 
 - (CGFloat)yCoordinateBelowStatusBar {
-#if TARGET_OS_TV
+#if TARGET_OS_TV || !NS_EXTENSION_UNAVAILABLE_IOS
     return 0;
 #else
     return [UIApplication sharedApplication].statusBarFrame.size.height;
@@ -202,7 +202,7 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
 }
 
 - (CGFloat)topInset {
-#if TARGET_OS_TV
+#if TARGET_OS_TV || !NS_EXTENSION_UNAVAILABLE_IOS
     return self.landscapeTopInset;
 #else
     if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {


### PR DESCRIPTION
[Some APIs Are Unavailable to App
Extensions](https://developer.apple.com/library/ios/documentation/Genera
l/Conceptual/ExtensibilityPG/ExtensionOverview.html#//apple_ref/doc/uid/
TP40014214-CH2-SW6)

According To Apple Doc:

> Because of its focused role in the system, an app extension is
ineligible to participate in certain activities. An app extension
cannot:

>  Access a sharedApplication object, and so cannot use any of the
methods on that object

Test in my own app.We need the `NS_EXTENSION_UNAVAILABLE_IOS`  preprocessor macro to make it
available in App extension