### PR TITLE
 Fix call on didTapOnBackgroundViewCompletionHandler

### DIFF
--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.h
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.h
@@ -109,7 +109,7 @@ typedef NS_ENUM(NSInteger, MZFormSheetActionWhenKeyboardAppears) {
 
 /**
  The movement action to use when the keyboard appears.
- By default, this is MZFormSheetActionWhenKeyboardAppears.
+ By default, this is MZFormSheetActionWhenKeyboardAppearsDoNothing.
  */
 @property (nonatomic, assign) MZFormSheetActionWhenKeyboardAppears movementActionWhenKeyboardAppears MZ_APPEARANCE_SELECTOR;
 

--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.m
@@ -149,6 +149,11 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
     }
 }
 
+- (void)setDidTapOnBackgroundViewCompletionHandler:(MZFormSheetPresentationControllerTapHandler)didTapOnBackgroundViewCompletionHandler {
+    _didTapOnBackgroundViewCompletionHandler = didTapOnBackgroundViewCompletionHandler;
+    [self addBackgroundTapGestureRecognizer];
+}
+
 #pragma mark - Init
 
 - (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController presentingViewController:(UIViewController *)presentingViewController {


### PR DESCRIPTION
@m1entus:
Actually if 'shouldDismissOnBackgroundViewTap' is set to NO 'didTapOnBackgroundViewCompletionHandler' can not be call

'didTapOnBackgroundViewCompletionHandler' should be called even if 'shouldDismissOnBackgroundViewTap' is set to NO