### PR TITLE
#58 hotfix

### DIFF
--- a/MZFormSheetPresentationController/MZFormSheetPresentationViewController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationViewController.m
@@ -140,9 +140,9 @@
 - (void)setAllowDismissByPanningPresentedView:(BOOL)allowDismissByPanningPresentedView {
     _allowDismissByPanningPresentedView = allowDismissByPanningPresentedView;
     if (_allowDismissByPanningPresentedView) {
-        [self addPresentaingViewDismissalPanGestureRecognizer];
+        [self addPresentingViewDismissalPanGestureRecognizer];
     } else {
-        [self removePresentaingViewDismissalPanGestureRecognizer];
+        [self removePresentingViewDismissalPanGestureRecognizer];
     }
 }
 
@@ -219,7 +219,7 @@
         }
         
         if (self.allowDismissByPanningPresentedView) {
-            [self addPresentaingViewDismissalPanGestureRecognizer];
+            [self addPresentingViewDismissalPanGestureRecognizer];
         }
 
         if (self.willPresentContentViewControllerHandler) {
@@ -259,14 +259,14 @@
 
 #pragma mark - UIGestureRecognizer
 
-- (void)addPresentaingViewDismissalPanGestureRecognizer {
+- (void)addPresentingViewDismissalPanGestureRecognizer {
     
-    [self removePresentaingViewDismissalPanGestureRecognizer];
+    [self removePresentingViewDismissalPanGestureRecognizer];
     self.presentedViewDissmisalPanGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleDismissalPanGestureRecognizer:)];
     [self.view addGestureRecognizer:self.presentedViewDissmisalPanGestureRecognizer];
 }
 
-- (void)removePresentaingViewDismissalPanGestureRecognizer {
+- (void)removePresentingViewDismissalPanGestureRecognizer {
     [self.presentedViewDissmisalPanGestureRecognizer.view removeGestureRecognizer:self.presentedViewDissmisalPanGestureRecognizer];
     self.presentedViewDissmisalPanGestureRecognizer = nil;
 }

--- a/MZFormSheetPresentationController/MZFormSheetPresentationViewControllerInteractiveAnimator.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationViewControllerInteractiveAnimator.m
@@ -150,8 +150,6 @@
 
     if (recognizer.state == UIGestureRecognizerStateBegan) {
         if ([self shouldFailGestureRecognizerForDismissDirection:dismissDirection location:location presentingView:presentingView]) {
-            recognizer.enabled = NO;
-            recognizer.enabled = YES;
             return;
         }
 


### PR DESCRIPTION
https://github.com/m1entus/MZFormSheetPresentationController/issues/58

I don't think it's necessary to disable the recognizer if `shouldFailGestureRecognizerForDismissDirection:location:presentingView:` returns `YES`.

As per [Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIGestureRecognizer_Class/index.html#//apple_ref/occ/instp/UIGestureRecognizer/enabled):
> If you change this property to NO while a gesture recognizer is currently recognizing a gesture, the gesture recognizer transitions to a cancelled state.

A recognizer in a cancelled state is not handled by `handleEdgeDismissalPanGestureRecognizer:dismissDirection:forPresentingView:fromViewController:`