### PR TITLE
MZ_APP_EXTENSIONS preprocessor macro to handle compilation for app extensions

### DIFF
--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.m
@@ -204,7 +204,7 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
 }
 
 - (CGFloat)yCoordinateBelowStatusBar {
-#if TARGET_OS_TV || !NS_EXTENSION_UNAVAILABLE_IOS
+#if TARGET_OS_TV || MZ_APP_EXTENSIONS
     return 0;
 #else
     return [UIApplication sharedApplication].statusBarFrame.size.height;
@@ -212,7 +212,7 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
 }
 
 - (CGFloat)topInset {
-#if TARGET_OS_TV || !NS_EXTENSION_UNAVAILABLE_IOS
+#if TARGET_OS_TV || MZ_APP_EXTENSIONS
     return self.landscapeTopInset;
 #else
     if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {

--- a/README.md
+++ b/README.md
@@ -355,6 +355,24 @@ override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
 
 MZFormSheetPresentationController uses ARC.
 
+## App Extensions
+
+Some position calculations access [UIApplication sharedApplication] which is not permitted in application extensions. If you want to use MZFormSheetPresentationController in extensions add the MZ_APP_EXTENSIONS=1 preprocessor macro in the corresponding target.
+
+If you use Cocoapods you can use a post install hook to do that:
+```ruby
+post_install do |installer|
+    installer.pods_project.targets.each do |target|
+        if target.name == "MZFormSheetPresentationController"
+            target.build_configurations.each do |config|
+                config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+                config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'MZ_APP_EXTENSIONS=1'
+            end
+        end
+    end
+end
+```
+
 ## Contact
 
 [Michal Zaborowski](http://github.com/m1entus)


### PR DESCRIPTION
* Replaced NS_EXTENSION_UNAVAILABLE_IOS with a project specific MZ_APP_EXTENSIONS preprocessor macro that correctly works in the main app target.
* Updated README on how to use the library in app extensions.

Discussion here:
https://github.com/m1entus/MZFormSheetPresentationController/commit/b8595065f4215b6c2679f6475a4d0dfda196169c#commitcomment-17006310 