### PR TITLE
Nested framework fix for Carthage build

### DIFF
--- a/Framework/MZFormSheetPresentationControllerFramework.h
+++ b/Framework/MZFormSheetPresentationControllerFramework.h
@@ -17,6 +17,8 @@ FOUNDATION_EXPORT const unsigned char MZFormSheetPresentationControllerVersionSt
 
 #import <MZFormSheetPresentationController/MZFormSheetPresentationController.h>
 #import <MZFormSheetPresentationController/MZFormSheetPresentationViewController.h>
+#import <MZFormSheetPresentationController/MZFormSheetPresentationViewControllerSegue.h>
+#import <MZFormSheetPresentationController/MZFormSheetPresentationController Swift Example-Bridging-Header.h>
 
 #import <MZFormSheetPresentationController/MZTransition.h>
 
@@ -26,7 +28,8 @@ FOUNDATION_EXPORT const unsigned char MZFormSheetPresentationControllerVersionSt
 #import <MZFormSheetPresentationController/MZFormSheetPresentationViewControllerInteractiveTransitioning.h>
 
 #import <MZFormSheetPresentationController/MZFormSheetPresentationContentSizing.h>
-#import <MZFormSheetPresentationController/MZFormSheetPresentationViewControllerSegue.h>
+#import <MZFormSheetPresentationController/MZFormSheetContentSizingNavigationController.h>
+#import <MZFormSheetPresentationController/MZFormSheetContentSizingNavigationControllerAnimator.h>
 
 #import <MZFormSheetPresentationController/MZBlurEffectAdapter.h>
-#import <MZFormSheetPresentationController/MZFormSheetPresentationController Swift Example-Bridging-Header.h>
+#import <MZFormSheetPresentationController/UIViewController+TargetViewController.h>

--- a/MZFormSheetPresentationController.xcodeproj/project.pbxproj
+++ b/MZFormSheetPresentationController.xcodeproj/project.pbxproj
@@ -183,7 +183,6 @@
 				468A6BF51C4B2FAD00F84D81 /* Frameworks */,
 				468A6BF61C4B2FAD00F84D81 /* Headers */,
 				468A6BF71C4B2FAD00F84D81 /* Resources */,
-				AE0D4D1C1C90802100A82E3B /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -234,23 +233,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		AE0D4D1C1C90802100A82E3B /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/MZAppearance.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		468A6BF41C4B2FAD00F84D81 /* Sources */ = {


### PR DESCRIPTION
Michał,
My apologies for .... the 3rd? 4th? commit on this particular feature. When I finally went to submit a TestFlight build of my app I had a bunch of obscure validation errors. It turns out that there were still two problems: 
* some header files that were marked in the project as part of the framework but not copied into the framework directory
* a copy-frameworks step for MZAppearance that caused it to show up as an nested framework when built using Carthage. I believe that one of the previous commits added it in by mistake. 
