### PR TITLE
Prevent setting frame of `MZFormSheetPresentationViewControllerCustom…

### DIFF
--- a/MZFormSheetPresentationController/MZFormSheetPresentationViewController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationViewController.m
@@ -47,10 +47,17 @@
     // who is setting frame to [UIScreen mainScreen] when modally presented over
     // MZFormSheetPresentationViewController using UIModalPresentationFullScreen style !!!
     // Made this workaround to have less github issues, for people who is not reading docs :)
-
     if (self.viewController.presentedViewController && self.viewController.presentedViewController.modalPresentationStyle == UIModalPresentationFullScreen) {
         return;
     }
+    
+    // This is workaroud for UIViewControllerBuiltinTransitionViewAnimator
+    // who is setting frame to [UIScreen mainScreen] when modally presented over
+    // MZFormSheetPresentationViewController using UIModalPresentationCurrentContext style !!!
+    if (self.viewController.presentedViewController && self.viewController.presentedViewController.modalPresentationStyle == UIModalPresentationCurrentContext) {
+        return;
+    }
+    
     [super setFrame:frame];
 }
 


### PR DESCRIPTION
When we try to present any view controller over `MZFormSheetPresentationViewController` modally and using `UIModalPresentationCurrentContext` (so that modally presented controller have the same bounds as child view controller of `MZFormSheetPresentationViewController` has) after dismissing this modally presented controller the frame of the child view controller of `MZFormSheetPresentationViewController` is set to `[UIScreen mainScreen]`.

To prevent this workaround is added like as it is done for `UIModalPresentationFullScreen` presentation style in the existing code.