### PR TITLE
Use UIPropertyViewAnimator on iOS 10 to animate blur radius

### DIFF
--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.h
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.h
@@ -105,6 +105,13 @@ typedef NS_ENUM(NSInteger, MZFormSheetActionWhenKeyboardAppears) {
  */
 @property (nonatomic, strong, nullable) UIColor *backgroundColor MZ_APPEARANCE_SELECTOR;
 
+/**
+ The background visibility percentage.
+ If UIViewPropertyAnimator is available, this adjusts the blur amount, otherwise,
+ it changes dimmingView's alpha.
+ */
+@property (nonatomic) CGFloat backgroundVisibilityPercentage;
+
 /*
  The intensity of the blur effect. See UIBlurEffectStyle for valid options.
  By default, this is UIBlurEffectStyleLight

--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.m
@@ -40,7 +40,9 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
 
 @property (nonatomic, assign, getter=isKeyboardVisible) BOOL keyboardVisible;
 @property (nonatomic, strong) NSValue *screenFrameWhenKeyboardVisible;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 @property (nonatomic, strong) UIViewPropertyAnimator *propertyAnimator;
+#endif
 @end
 
 @implementation MZFormSheetPresentationController
@@ -200,11 +202,13 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
         self.dimmingView.backgroundColor = [UIColor clearColor];
         [self.dimmingView addSubview:self.blurBackgroundView];
         
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
         if ([UIViewPropertyAnimator class]) {
             self.propertyAnimator = [[UIViewPropertyAnimator alloc] initWithDuration:1.0 curve:UIViewAnimationCurveLinear animations:^{
                 self.blurBackgroundView.effect = nil;
             }];
         }
+#endif
     } else {
         self.dimmingView.backgroundColor = self.backgroundColor;
     }
@@ -212,11 +216,15 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
 
 - (void)setBackgroundVisibilityPercentage:(CGFloat)backgroundVisibilityPercentage {
     _backgroundVisibilityPercentage = backgroundVisibilityPercentage;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
     if (self.propertyAnimator && [self shouldTransitionBlur]) {
         self.propertyAnimator.fractionComplete = backgroundVisibilityPercentage;
     } else {
         self.dimmingView.alpha = 1.0 - backgroundVisibilityPercentage;
     }
+#else
+    self.dimmingView.alpha = 1.0 - backgroundVisibilityPercentage;
+#endif
 }
 
 - (CGFloat)yCoordinateBelowStatusBar {

--- a/MZFormSheetPresentationController/MZFormSheetPresentationViewControllerInteractiveAnimator.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationViewControllerInteractiveAnimator.m
@@ -267,7 +267,7 @@
             percentComplete = 0;
         }
         
-        presentationController.dimmingView.alpha = (1.0 - percentComplete);
+        presentationController.backgroundVisibilityPercentage = percentComplete;
         
         
         if (self.currentDirection == MZFormSheetPanGestureDismissDirectionLeft) {
@@ -291,7 +291,7 @@
             sourceViewFrame.origin.y = CGRectGetMinY(self.sourceViewInitialFrame) + (distanceToPass * percentComplete);
         }
     } else {
-        presentationController.dimmingView.alpha = (1.0 - fabs(percentComplete));
+        presentationController.backgroundVisibilityPercentage = percentComplete;
         
         
         distanceToPass = CGRectGetHeight(transitionContext.containerView.bounds) - CGRectGetMidY(self.sourceViewInitialFrame);
@@ -336,7 +336,7 @@
     
     [UIView animateWithDuration:self.transitionDuration delay:0 usingSpringWithDamping:0.7 initialSpringVelocity:0.3 options:0 animations:^{
         sourceView.frame = sourceViewFrame;
-        presentationController.dimmingView.alpha = 0.0;
+        presentationController.backgroundVisibilityPercentage = 1.0;
     } completion:^(BOOL finished) {
         [transitionContext completeTransition:YES];
     }];
@@ -350,7 +350,7 @@
     MZFormSheetPresentationController *presentationController = (id)[fromViewController presentationController];
 
     [UIView animateWithDuration:self.transitionDuration delay:0 usingSpringWithDamping:0.5 initialSpringVelocity:0.3 options:0 animations:^{
-        presentationController.dimmingView.alpha = 1.0;
+        presentationController.backgroundVisibilityPercentage = 0.0;
         sourceView.frame = self.sourceViewInitialFrame;
     } completion:^(BOOL finished) {
         [transitionContext completeTransition:NO];


### PR DESCRIPTION
This fixes issue #101 

On iOS 10, this uses the new UIViewPropertyAnimator class to animate the blur radius by changing the effect, I tested this with interactive transition and normal ones and it seems to work fine.

On iOS 9, it falls back to changing dimmingView's alpha. This is "fine" (although discouraged in docs, it works I guess) for iOS 9 since changing the alpha worked before, but this pull requests animates the blur coming into view by using UIView's animateWithDuration (only for non interactive transitions). On the upside, this change looks much better.

On iOS 8, nothing changes.

This should compile on the previous compatible SDK, and I tested behaviour both when using blur effects and when not, and it seems to work fine.