### PR TITLE
Exact size calculation when using UILayoutFittingCompressedSize

### DIFF
--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.m
@@ -499,6 +499,8 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
     UIView *contentView = presentationViewController.contentViewController.view;
     
     if (CGSizeEqualToSize(contentViewSize, UILayoutFittingCompressedSize)) {
+        [contentView setNeedsLayout];
+        [contentView layoutIfNeeded];
         formSheetRect.size = [contentView systemLayoutSizeFittingSize: contentViewSize];
     } else if (CGSizeEqualToSize(contentViewSize, UILayoutFittingExpandedSize)) {
         formSheetRect.size = [contentView systemLayoutSizeFittingSize: self.containerView.bounds.size];


### PR DESCRIPTION
This PR address an issue I found when using UILayoutFittingCompressedSize to dynamically size a popup with multiline labels. The popup had a fixed with constraint and I wanted to calculate the height dynamically to fit exactly fit the text. 

This is what I got when I set the `presentationController.contentViewSize` attribute to `UILayoutFittingCompressedSize`. As you can see the calculated height is not exact (look at the bottom part of the popup):

![img_0549](https://cloud.githubusercontent.com/assets/41727/21383414/f49af9b6-c765-11e6-93c5-60bb1ea6dec6.jpg)

By forcing autolayout to run before invoking `[contentView systemLayoutSizeFittingSize: contentViewSize]` the view is then measured correctly and that sizing issue disappeared.