### PR TITLE
Fix UIPropertyViewAnimator crash on iOS 11

### DIFF
--- a/MZFormSheetPresentationController/MZFormSheetPresentationController.m
+++ b/MZFormSheetPresentationController/MZFormSheetPresentationController.m
@@ -57,6 +57,9 @@ CGFloat const MZFormSheetPresentationControllerDefaultAboveKeyboardMargin = 20;
     
     [self.dimmingView removeGestureRecognizer:self.backgroundTapGestureRecognizer];
     self.backgroundTapGestureRecognizer = nil;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+    [self.propertyAnimator stopAnimation:YES];
+#endif
 }
 
 #pragma mark - Appearance


### PR DESCRIPTION
On iOS 11, if the pan gesture is used to interactively dismiss, it will
crash when trying to dealloc UIViewPropertyAnimator because the
animation has not finished or has not been explicitly stopped.

This fixes the crash by explicitly stopping the animation in dealloc.

The use of UIViewPropertyAnimator was introduced in
https://github.com/m1entus/MZFormSheetPresentationController/pull/110